### PR TITLE
Remove deprecated code

### DIFF
--- a/14_Deinitialization.playground/Contents.swift
+++ b/14_Deinitialization.playground/Contents.swift
@@ -23,10 +23,10 @@ Superclass deinitializers are always called, even if a subclass does not provide
 
 class Bank {
     static var coinsInBank = 10_000
-    static func vendCoins(var numberOfCoinsToVend: Int) -> Int {
-        numberOfCoinsToVend = min(numberOfCoinsToVend, coinsInBank)
-        coinsInBank -= numberOfCoinsToVend
-        return numberOfCoinsToVend
+    static func vendCoins(numberOfCoinsToVend: Int) -> Int {
+        let numberOfCoinsAllowedToVend = min(numberOfCoinsToVend, coinsInBank)
+        coinsInBank -= numberOfCoinsAllowedToVend
+        return numberOfCoinsAllowedToVend
     }
     static func receiveCoins(coins: Int) {
         coinsInBank += coins

--- a/17_Error_Handling.playground/Contents.swift
+++ b/17_Error_Handling.playground/Contents.swift
@@ -84,7 +84,7 @@ class VendingMachine {
         }
         
         coinsDeposited -= item.price
-        --item.count
+        item.count -= 1
         inventory[name] = item
         dispenseSnack(name)
     }

--- a/20_Extensions.playground/Contents.swift
+++ b/20_Extensions.playground/Contents.swift
@@ -172,11 +172,12 @@ Subscripts
 */
 
 extension Int {
-    subscript(var digitIndex: Int) -> Int {
+    subscript(digitIndex: Int) -> Int {
+        var index = digitIndex
         var decimalBase = 1
-        while digitIndex > 0 {
+        while index > 0 {
             decimalBase *= 10
-            --digitIndex
+            index -= 1
         }
         return (self / decimalBase) % 10
     }

--- a/22_Generics.playground/Contents.swift
+++ b/22_Generics.playground/Contents.swift
@@ -175,7 +175,7 @@ without knowing what that type is for a specific container.
 */
 
 protocol Container {
-    typealias ItemType
+    associatedtype ItemType
     mutating func append(item: ItemType)
     var count: Int { get }
     subscript(i: Int) -> ItemType { get }


### PR DESCRIPTION
- `--` operator is deprecated now and will be removed with Swift 3.0
- `var` function parameters are deprecated now and will be removed with Swift 3.0
- `typealias` keyword for associated type declarations is deprecated now and will be removed with Swift 3.0, use `associatedtype` instead.
