### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 # The Swift Summary Book
 A summary of Apple's Swift language written on Playgrounds.
 
-###Why this summary?
+### Why this summary?
 Apple's documentation is great for learning Swift, but who's got the time to read all that? :smile:
 
 This summary cuts to the chase. It is directly written on the Playgrounds platform, which makes it very interactive.
 You can tinker around with it as much as you like!
 
-##Inside the Box
+## Inside the Box
 Once you've downloaded or cloned the repository and you open it with Xcode, you'll find most of the chapters from Apple's documentation, plus a *Resources* folder that contains extra material. The numbering in each chapter is consistent with Apple's. Chapters with a ~~strikethrough~~ have not been added to the book yet as being considered *unimportant*. More specifically, you'll find:
 
 **Chapters**
@@ -44,37 +44,37 @@ Once you've downloaded or cloned the repository and you open it with Xcode, you'
 **Resources**
 - Higher Order Functions
 
-##How should I install this?
+## How should I install this?
 Getting started with The Swift Summary Book is a piece of 🎂:
 
 1. Just clone or download the repository.
 2. You need to have Xcode v8.0 or above. You can download it [here](https://developer.apple.com/xcode/).
 3. Open the `.swift` file with Xcode and *voilà*!
 
-##What are the features?
+## What are the features?
 The Swift Summary Book takes advantage of the Playground platform and many of its powerful capabilities:
 * The book is made of a single file that contains all chapters inside, which allows for easy access.
 * Chapters use the Playground Markup Language, which brings rich documentation to the code examples.
 * Every chapter has Page Linking, which allows to go back and forth from one chapter to the next, previous or another that was mentioned with in the chapter.
 
 
-##Keep in mind
+## Keep in mind
 The Swift language is still under rapid development, which means that the documentation is changing all the time, and some sections might break at a given time.
 
 
-##You can help too!
+## You can help too!
 * Help me keep this summary :+1: by creating pull requests and issues!
 * Share this project and make sure you and others give it a ⭐
 
 
-##You can find me on
+## You can find me on
 <img src="http://25.media.tumblr.com/tumblr_m5xo9frXtv1rysqvgo1_1280.png" alt="Web logo" height="17" > http://karmy.co
 
 <img src="https://cdn3.iconfinder.com/data/icons/free-social-icons/67/twitter_circle_black-512.png" alt="Twitter logo" height="17" > http://twitter.com/jkarmy
 
 Karmy :sunglasses:
 
-##License
+## License
 The MIT License (MIT)
 
 Copyright (c) 2016 Juan Antonio Karmy


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
